### PR TITLE
compatibility with lighthouse 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ lighthouse.example_com.speed-index.min 869
 lighthouse.example_com.speed-index.median 900
 lighthouse.example_com.estimated-input-latency.min 12
 lighthouse.example_com.estimated-input-latency.median 12
-lighthouse.example_com.time-to-first-byte.min 106
-lighthouse.example_com.time-to-first-byte.median 107
+lighthouse.example_com.server-response-time.min 106
+lighthouse.example_com.server-response-time.median 107
 lighthouse.example_com.first-cpu-idle.min 824
 lighthouse.example_com.first-cpu-idle.median 825
 lighthouse.example_com.interactive.min 824
@@ -66,7 +66,7 @@ The list of the collected metrics is:
 -   first-meaningful-paint
 -   speed-index
 -   estimated-input-latency
--   time-to-first-byte
+-   server-response-time
 -   first-cpu-idle
 -   interactive
 -   network-requests

--- a/__tests__/graphite-client.js
+++ b/__tests__/graphite-client.js
@@ -20,7 +20,7 @@ describe('graphite-client', () => {
                 mean: 50,
                 median: 60,
             },
-            'time-to-first-byte': {
+            'server-response-time': {
                 min: 50,
                 max: 200,
                 mean: 121,
@@ -35,10 +35,10 @@ describe('graphite-client', () => {
                 'my-prefix.interactive.max': 100,
                 'my-prefix.interactive.mean': 50,
                 'my-prefix.interactive.median': 60,
-                'my-prefix.time-to-first-byte.min': 50,
-                'my-prefix.time-to-first-byte.max': 200,
-                'my-prefix.time-to-first-byte.mean': 121,
-                'my-prefix.time-to-first-byte.median': 110,
+                'my-prefix.server-response-time.min': 50,
+                'my-prefix.server-response-time.max': 200,
+                'my-prefix.server-response-time.mean': 121,
+                'my-prefix.server-response-time.median': 110,
             },
             expect.any(Function)
         );

--- a/__tests__/result-mapper.js
+++ b/__tests__/result-mapper.js
@@ -10,7 +10,7 @@ describe('result-mapper', () => {
             'first-meaningful-paint': 825,
             'speed-index': 991,
             'estimated-input-latency': 12,
-            'time-to-first-byte': 109,
+            'server-response-time': 109,
             'first-cpu-idle': 900,
             interactive: 903,
             'network-requests': 2,

--- a/__tests__/result-mock.json
+++ b/__tests__/result-mock.json
@@ -222,10 +222,10 @@
                 ]
             }
         },
-        "time-to-first-byte": {
-            "id": "time-to-first-byte",
+        "server-response-time": {
+            "id": "server-response-time",
             "title": "Server response times are low (TTFB)",
-            "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).",
+            "description": "Server response time identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).",
             "score": 1,
             "scoreDisplayMode": "binary",
             "numericValue": 109.03200000000001,
@@ -1761,7 +1761,7 @@
                     "group": "load-opportunities"
                 },
                 {
-                    "id": "time-to-first-byte",
+                    "id": "server-response-time",
                     "weight": 0,
                     "group": "load-opportunities"
                 },
@@ -2429,18 +2429,18 @@
                     "path": "audits[estimated-input-latency].displayValue"
                 }
             ],
-            "lighthouse-core/audits/time-to-first-byte.js | title": [
-                "audits[time-to-first-byte].title"
+            "lighthouse-core/audits/server-response-time.js | title": [
+                "audits[server-response-time].title"
             ],
-            "lighthouse-core/audits/time-to-first-byte.js | description": [
-                "audits[time-to-first-byte].description"
+            "lighthouse-core/audits/server-response-time.js | description": [
+                "audits[server-response-time]].description"
             ],
-            "lighthouse-core/audits/time-to-first-byte.js | displayValue": [
+            "lighthouse-core/audits/server-response-time.js | displayValue": [
                 {
                     "values": {
                         "timeInMs": 109.03200000000001
                     },
-                    "path": "audits[time-to-first-byte].displayValue"
+                    "path": "audits[server-response-time].displayValue"
                 }
             ],
             "lighthouse-core/audits/metrics/first-cpu-idle.js | title": [

--- a/src/result-mapper.js
+++ b/src/result-mapper.js
@@ -3,7 +3,7 @@ exports.map = result => ({
     'first-meaningful-paint': Math.floor(result.audits['first-meaningful-paint'].numericValue),
     'speed-index': Math.floor(result.audits['speed-index'].numericValue),
     'estimated-input-latency': Math.floor(result.audits['estimated-input-latency'].numericValue),
-    'time-to-first-byte': Math.floor(result.audits['time-to-first-byte'].numericValue),
+    'server-response-time': Math.floor(result.audits['server-response-time'].numericValue),
     'first-cpu-idle': Math.floor(result.audits['first-cpu-idle'].numericValue),
     interactive: Math.floor(result.audits['interactive'].numericValue),
     'network-requests': result.audits['network-requests'].numericValue,


### PR DESCRIPTION
Metric "time-to-first-byte" was renamed to "server-response-time" in lighthouse 6.x. See "Breaking changes for programmatic users" at https://github.com/GoogleChrome/lighthouse/releases/tag/v6.0.0.